### PR TITLE
remove slack archive link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,3 @@ The creation of new channels has been limited to admins only. If you have a reas
 
 ### Seeking Work
 - The first line should begin with `| seeking work | <location / willing to relocate> | <brief skills & description of what kind of work is being sought>`
-
-## Misc
-- We have archivable history! Invite `archivebot` to the channel and it will be archived past the limit of Slack on https://elmlang.slackarchive.io.


### PR DESCRIPTION
fix #7 

The outdatedness of the link was confirmed in #admin-help by @brianhicks

funnily enough, you won't be able to tell in some time, because there won't be archives to prove it ;)